### PR TITLE
Add a rule to require `let` and `const` on top of their containing scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Then configure the rules you want to use under the rules section.
         "checkImportsOnTop": true,
         "checkBlockSeparation": false
       }
-    ]
+    ],
+    "voog/let-const-on-top": ["error"]
   }
 }
 ```
@@ -143,3 +144,9 @@ A rule to enforce the following conditions:
 
    If true, enforce the requirement that every import declaration must appear
    before any other statement in the file. Defaults to true.
+
+### `let-const-on-top`
+
+Require let and const declarations at the top of their containing scope. This
+rule is currently not configurable.
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,8 @@ module.exports = {
             },
             ignore: ['utils/[A-Z]', '^\\./[a-z]']
           }
-        ]
+        ],
+        'voog/let-const-on-top': ['error']
       }
     }
   }

--- a/lib/rules/let-const-on-top.js
+++ b/lib/rules/let-const-on-top.js
@@ -1,0 +1,35 @@
+
+const verifyVarDeclsOnTop = (block, {report}) => {
+  let nonVarNodeSeen = false;
+
+  block.body.forEach(node => {
+    const isNodeVarDecl = node.type === 'VariableDeclaration';
+    const isNodeLetConst = isNodeVarDecl && (node.kind === 'let' || node.kind === 'const');
+
+    if (isNodeLetConst && nonVarNodeSeen) {
+      report({
+        node,
+        message: 'let / const declarations must appear before any other statements in block scope'
+      });
+    }
+    else if (!isNodeVarDecl) {
+      nonVarNodeSeen = true;
+    }
+  });
+};
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require let and const declarations at the top of their containing scope'
+    },
+    schema: []
+  },
+
+  create: context => {
+    return {
+      BlockStatement: block => verifyVarDeclsOnTop(block, {report: context.report})
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-voog",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A collection of ESLint rules for import declaration ordering and more",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/enforce-import-ordering.js
+++ b/tests/lib/rules/enforce-import-ordering.js
@@ -1,8 +1,6 @@
-const RuleTester = require('eslint').RuleTester;
+const {compileTests, getRuleTester} = require('../utils.js');
 
 const rule = require('../../../lib/rules/enforce-import-ordering');
-
-const ruleTester = new RuleTester({parserOptions: {ecmaVersion: 2022, sourceType: 'module'}});
 
 const testSets = {
   ordering: () => {
@@ -218,31 +216,4 @@ const testSets = {
   }
 };
 
-const attachOptions = (tests, options) =>
-  options ? tests.map(test => ({...test, options: [test.options || options]})) : tests
-
-const compileTests = () => {
-
-  // Compile the expected tests structure from the internal hierarchical test
-  // sets structure. The latter is an object whose every value is a function
-  // returning a test set containing `valid` and `invalid` test cases, and:
-  //
-  // - options - common options applied to each test case, unless the test
-  //   case has its own `options`
-
-  return Object.values(testSets).reduce(
-    (acc, makeTestSet) => {
-      const testSet = makeTestSet();
-      const valid = attachOptions(testSet.valid, testSet.options);
-      const invalid = attachOptions(testSet.invalid, testSet.options);
-
-      return {
-        valid: [...acc.valid, ...valid],
-        invalid: [...acc.invalid, ...invalid]
-      };
-    },
-    {valid: [], invalid: []}
-  );
-}
-
-ruleTester.run('enforce-import-ordering', rule, compileTests());
+getRuleTester().run('enforce-import-ordering', rule, compileTests(testSets));

--- a/tests/lib/rules/let-const-on-top.js
+++ b/tests/lib/rules/let-const-on-top.js
@@ -1,0 +1,81 @@
+const {compileTests, getRuleTester} = require('../utils.js');
+
+const rule = require('../../../lib/rules/let-const-on-top');
+
+const testSets = {
+  all: () => {
+    return {
+      valid: [
+        {
+          name: 'let / const are on top',
+          code: `
+            () => {
+              let x;
+              const y = 0x808;
+
+              1;
+
+              return y;
+            };
+          `
+        },
+        {
+          name: 'var declarations are ignored',
+          code: `
+            () => {
+              let x;
+              var w;
+              const y = 0xF00BA7;
+
+              1;
+
+              var z;
+            };
+          `
+        },
+        {
+          name: 'program scope is ignored',
+          code: `
+            let x;
+            const y = 0xDECAFBAD;
+
+            1;
+
+            let z;
+          `
+        },
+      ],
+
+      invalid: [
+        {
+          name: 'let / const are not on top',
+          code: `
+            () => {
+              let x;
+              const y = 0xDEADBEEF;
+
+              1;
+
+              let z;
+            };
+          `,
+          errors: 1
+        },
+        {
+          name: 'let / const are not on top in inner scope',
+          code: `
+            () => {
+              while (true) {
+                1;
+                let x;
+              }
+            };
+          `,
+          errors: 1
+        },
+      ]
+    };
+  }
+};
+
+getRuleTester().run('let-const-on-top', rule, compileTests(testSets));

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,0 +1,37 @@
+
+const RuleTester = require('eslint').RuleTester;
+
+const attachOptions = (tests, options) =>
+  options ? tests.map(test => ({...test, options: [test.options || options]})) : tests
+
+const getRuleTester = () =>
+  new RuleTester({parserOptions: {ecmaVersion: 2022, sourceType: 'module'}});
+
+const compileTests = testSets => {
+
+  // Compile the expected tests structure from the internal hierarchical test
+  // sets structure. The latter is an object whose every value is a function
+  // returning a test set containing `valid` and `invalid` test cases, and:
+  //
+  // - options - common options applied to each test case, unless the test
+  //   case has its own `options`
+
+  return Object.values(testSets).reduce(
+    (acc, makeTestSet) => {
+      const testSet = makeTestSet();
+      const valid = attachOptions(testSet.valid, testSet.options);
+      const invalid = attachOptions(testSet.invalid, testSet.options);
+
+      return {
+        valid: [...acc.valid, ...valid],
+        invalid: [...acc.invalid, ...invalid]
+      };
+    },
+    {valid: [], invalid: []}
+  );
+}
+
+module.exports = {
+  compileTests,
+  getRuleTester
+};


### PR DESCRIPTION
The changeset adds the `let-const-on-top` rule requiring all `let` and `const` declarations at top of their containing scope, _except_ the program / module (uppermost) scope. This rule completely ignores `var` declarations as ESLint already contains rules to deal with those.

Rationale: increase readability and visibility by requring all variables and constants to be declared at the top of block scopes.

## Testing

In your project, temporarily modify ESLint configuration so that `plugins` includes `"voog"` and `rules` contains only

```
"voog/let-const-on-top": ["error"]
```

Then clone `eslint-voog`, link it to your project and run ESLint over the codebase to inspect the results. Execute `yarn test` to run the test suite.

```
$ git clone git@github.com:Voog/eslint-voog.git
$ cd eslint-voog
$ git checkout rule_let_const_on_top
$ yarn test
$ yarn link
$ cd /my/project
$ yarn link eslint-plugin-voog
$ npx eslint -- 'app/assets/javascripts/**/*.js'
```