### PR TITLE
Classify import declarations as `util` more eagerly in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,16 @@ Detect React index modules matching the regular expression
 importing from its containing directory and export declarations re-exporting
 previously imported symbols.
 
+## Debugging
+
+`eslint-plugin-voog` uses the [`debug`](https://www.npmjs.com/package/debug)
+package for debugging. To turn on debugging for a specific rule, set the `DEBUG`
+environment variable to `eslint-plugin-voog:<rule>`. To turn on debugging
+globally for the plugin, set `DEBUG` to `eslint-plugin-voog:*`:
+
+```
+$ DEBUG=eslint-plugin-voog:enforce-import-ordering
+$ npx eslint
+$ DEBUG='eslint-plugin-voog:*'
+$ npx eslint
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,8 @@ module.exports = {
               'css'
             ],
             blockMembershipTests: {
-              action: '(^|/)actions(/|\\.js|$)',
               util: '(^|/)utils(/|\\.js|$)',
+              action: '(^|/)actions(/|\\.js|$)',
               constant: {namedTest: 'constant'},
               image: '\\.(svg|png|jpe?g)(\\?\\w+)?$',
               css: '\\.css(\\?\\w+)?$',

--- a/lib/rules/enforce-import-ordering.js
+++ b/lib/rules/enforce-import-ordering.js
@@ -7,6 +7,7 @@
 // - Import declarations must appear before any other statements in a
 //   source file (unless `checkImportsOnTop` is explicitly set to false).
 
+const debug = require('debug')('eslint-plugin-voog:enforce-import-ordering');
 const sortedUniqBy = require('lodash/sortedUniqBy');
 const tail = require('lodash/tail');
 const upperFirst = require('lodash/upperFirst');
@@ -194,12 +195,16 @@ module.exports = {
       },
 
       ImportDeclaration: node => {
+        const type = classifyImportDecl(node, passedContext);
+
         importDecls.push({
           node,
-          type: classifyImportDecl(node, passedContext),
+          type,
           start: node.range[0],
           end: node.range[1],
         });
+
+        debug(`Saw '${node.source.value}', classified as "\x1B[30;1m${type}\x1B[m"`);
       },
 
       'Program:exit': () => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
+    "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "requireindex": "^1.2.0"
   },

--- a/tests/lib/rules/enforce-import-ordering.js
+++ b/tests/lib/rules/enforce-import-ordering.js
@@ -1,6 +1,7 @@
 const {compileTests, getRuleTester} = require('../utils.js');
 
-const rule = require('../../../lib/rules/enforce-import-ordering');
+const defaultConfig = require('../../../lib').configs.voog.rules['voog/enforce-import-ordering'][1];
+const rule = require('../../../lib/rules/enforce-import-ordering')
 
 const testSets = {
   ordering: () => {
@@ -213,7 +214,26 @@ const testSets = {
 
       options: [options]
     }
-  }
+  },
+
+  defaultConfig: () => {
+    return {
+      valid: [],
+
+      invalid: [
+        {
+          name: 'Default config: actions and action utils are considered separate blocks',
+          code: `
+            import {action} from 'path/actions';
+            import {actionUtil} from 'path/actions/utils';
+          `,
+          errors: 1
+        }
+      ],
+
+      options: [defaultConfig]
+    }
+  },
 };
 
 getRuleTester().run('enforce-import-ordering', rule, compileTests(testSets));

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,7 +504,7 @@ debug@4.3.3:
   dependencies:
     ms "2.1.2"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==


### PR DESCRIPTION
The changeset adds a tweak to the default config so that import declarations are classified as `util` more eagerly. Previously, the declarations

```js
import {bindDispatch} from 'actions/utils';
import {cartesian} from 'shared/utils';
```

would have required two newlines separating the statements, as the first would have been classified as `action` and the second as `util`. Now, these are both classified as `util`.

Also, the `debug` package has been employed to turn on granular logging as required.

## Testing

In your project, temporarily modify ESLint configuration so that `plugins` is `["voog"]`, `extends` is `"plugin:voog/voog"` and `rules` is empty or not present.

Then clone `eslint-voog`, link it to your project and run ESLint over the codebase to inspect the results. Execute `yarn test` to run the test suite.

```
$ git clone git@github.com:Voog/eslint-voog.git
$ cd eslint-voog
$ git checkout default_config_classify_as_utils_eagerly
$ yarn test
$ yarn link
$ cd /my/project
$ yarn link eslint-plugin-voog
$ npx eslint -- 'app/assets/javascripts/**/*.js'
```