### PR TITLE
Classify declarations as a constants import less eagerly

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ A rule to enforce the following conditions:
   Named tests are invoked by a structure `{"namedTest": <classifier>}` where
   `<classifier>` is a string referring to a built-in import declaration
   classifier.  Currently the only supported classifier is `constant` which
-  matches if at least one of the imported symbols consists solely of uppercase
-  characters or underscores and begins with an uppercase character. Note that:
+  matches if all of the imported symbols consist solely of uppercase characters
+  or underscores and begin with an uppercase character. Note that:
 
   * Every `blockOrder` member is required to have a corresponding entry in
     `blockMembershipTests`.

--- a/lib/rules/enforce-import-ordering.js
+++ b/lib/rules/enforce-import-ordering.js
@@ -15,7 +15,9 @@ const upperFirst = require('lodash/upperFirst');
 const CONSTANT_REGEX = /^[A-Z][A-Z_]+$/;
 
 const NAMED_TESTS = {
-  constant: node => node.specifiers.some(s => CONSTANT_REGEX.test((s.imported || s.local).name))
+  constant: node =>
+    !!node.specifiers.length &&
+    node.specifiers.every(s => CONSTANT_REGEX.test((s.imported || s.local).name))
 };
 
 const compileOptions = context => {

--- a/tests/lib/rules/enforce-import-ordering.js
+++ b/tests/lib/rules/enforce-import-ordering.js
@@ -216,6 +216,44 @@ const testSets = {
     }
   },
 
+  constantNamedTest: () => {
+    const options = {
+      blockOrder: ['constant', 'any'],
+      blockMembershipTests: {
+        constant: {namedTest: 'constant'},
+        any: ''
+      },
+      checkBlockSeparation: true
+    };
+
+    return {
+      valid: [
+        {
+          name: 'All declarations with only constant imports match the constant named test',
+          code: `
+            import CONSTANT_A from 'path';
+            import {CONSTANT_B} from 'path';
+            import CONSTANT_C, {CONSTANT_D} from 'path';
+            import {CONSTANT_E, CONSTANT_F} from 'path';
+          `
+        }
+      ],
+
+      invalid: [
+        {
+          name: 'Declarations with some non-constant imports do not match the constant named test',
+          code: `
+            import CONSTANT_A from 'path';
+            import Class, {CONSTANT_B} from 'path';
+          `,
+          errors: [{message: /must be separated/}]
+        }
+      ],
+
+      options: [options]
+    };
+  },
+
   defaultConfig: () => {
     return {
       valid: [],


### PR DESCRIPTION
Require all imported names to consist of uppercase characters and underscores to be classified as a constants import. Earlier an import was classified as a constants import if at least one of the names satisfied this condition.

0.3.1 requires a workaround with the default configuration:

```js
import MultiInput from './MultiInput';

// some other imports 
 
import {MULTIPLE_VALUES} from './MultiInput'; // eslint-disable-line no-duplicate-imports
```

With the patch, no workaround is required as the first import declaration is no longer considered to be a constants import:

```js
import MultiInput, {MULTIPLE_VALUES} from './MultiInput';

// some other imports 
```

## Testing

In your project, temporarily modify ESLint configuration so that `plugins`
includes `"voog"` and `rules` contains only

```
"voog/<RULE>": ["error"]
```

Then clone `eslint-voog`, link it to your project and run ESLint over the
codebase to inspect the results. Execute `yarn test` to run the test suite.

```
$ git clone git@github.com:Voog/eslint-voog.git
$ cd eslint-voog
$ git checkout <BRANCH>
$ yarn test
$ yarn link
$ cd /my/project
$ yarn link eslint-plugin-voog
$ npx eslint -- 'app/assets/javascripts/**/*.js'
```